### PR TITLE
adding missing numpy import

### DIFF
--- a/dataflow/operators/eval/GeneralText/models/pair_qual_scorer.py
+++ b/dataflow/operators/eval/GeneralText/models/pair_qual_scorer.py
@@ -6,6 +6,7 @@ from dataflow.utils.registry import OPERATOR_REGISTRY
 from dataflow.utils.storage import DataFlowStorage
 from tqdm import tqdm
 from dataflow.utils.utils import get_logger
+import numpy as np
 
 @OPERATOR_REGISTRY.register()
 class PairQualScorer(OperatorABC):


### PR DESCRIPTION
In the  "DataFlow/dataflow/operators/eval/GeneralText/models/pair_qual_scorer.py", you lack import numpy as np, which would cause an error when run 
```bash
python test/test_pt_filter.py
```