### PR TITLE
[serving] set default `vllm_seed` param for `LocalModelLLMServing_vllm` to `None` to avoid warning

### DIFF
--- a/dataflow/serving/LocalModelLLMServing.py
+++ b/dataflow/serving/LocalModelLLMServing.py
@@ -20,7 +20,7 @@ class LocalModelLLMServing_vllm(LLMServingABC):
                  vllm_max_tokens: int = 1024,
                  vllm_top_k: int = 40,
                  vllm_repetition_penalty: float = 1.0,
-                 vllm_seed: int = 42,
+                 vllm_seed: int = None,
                  vllm_max_model_len: int = None,
                  vllm_gpu_memory_utilization: float=0.9,
                  ):
@@ -274,3 +274,4 @@ class LocalModelLLMServing_sglang(LLMServingABC):
         import gc;
         gc.collect()
         torch.cuda.empty_cache()
+        


### PR DESCRIPTION
-  Avoid `Warning: FlashInfer 0.2.3+ does not support per-request generators. Falling back to PyTorch-native implementation.` when using VLLM>=0.9.2 as backend.
- Related Links:
  - https://github.com/vllm-project/vllm/issues/17898
  - https://chatgpt.com/c/68786709-8100-800c-8d44-28437523da0d
  - https://github.com/flashinfer-ai/flashinfer/issues/1104