### PR TITLE
增加了多轮对话中，对部分user生成缺少assistant的情况修复

### DIFF
--- a/dataflow/operators/conversations/consistent_chat.py
+++ b/dataflow/operators/conversations/consistent_chat.py
@@ -105,11 +105,27 @@ class ConsistentChatGenerator(OperatorABC):
             try:
                 category = query_data['category']
                 turns = query_data['turns']
+                
+                # Ensure the number of turns matches the number of responses
+                num_user_turns = len(turns)
+                num_assistant_responses = len(response_data)
+                
+                if num_user_turns > num_assistant_responses:
+                    turns = turns[:num_assistant_responses]
+
                 conversation = []
                 for i in range(len(turns)):
                     conversation.append({"role": "user", "value": turns[i]})
                     if i < len(response_data):
                         conversation.append({"role": "assistant", "value": response_data[i]['response']})
+                
+                # Ensure conversation does not end with a user message
+                if conversation and conversation[-1]["role"] == "user":
+                    conversation.pop()
+
+                if not conversation:
+                    continue
+
                 formatted_data.append({
                     "category": category,
                     "conversation": conversation


### PR DESCRIPTION
修复的问题
在使用qwen-turbo、qwen2.5-32b和qwen3-coder-480b-a35b-instruct，均出现在很多轮次的输出中，有部分user没有assistant的回复。

解决方案
- 保证user和assistant的数量一致，如果assistant少于user，我将阶段user保证长度匹配
- 检查对话不会以用户消息结束，否则会被移除
- 
测试验证
- [x] 手动验证了我已有数据


关联 Issue: #184 (如果适用)