### PR TITLE
[feature] add docker support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,26 @@
+# Git
+.git
+.gitignore
+
+# Docker
+.dockerignore
+
+# IDE settings
+.vscode/
+.idea/
+
+# Python artifacts
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+*.egg-info/
+dist/
+build/
+*.egg
+*.whl
+
+# Virtual environments
+.venv
+venv/
+env/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+# Base Image
+FROM --platform=linux/amd64 nvidia/cuda:12.4.1-cudnn-runtime-ubuntu22.04
+
+# Environment variables
+ENV DEBIAN_FRONTEND=noninteractive \
+    LANG=C.UTF-8 LC_ALL=C.UTF-8 \
+    PYTHONUNBUFFERED=1 \
+    PIP_NO_CACHE_DIR=1
+
+# System dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      python3 python3-venv python3-pip python3-dev \
+      git build-essential pkg-config \
+      ffmpeg libgl1 libglib2.0-0 \
+      ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+
+# Python environment
+RUN python3 -m venv /opt/venv
+ENV PATH="/opt/venv/bin:${PATH}"
+RUN python -m pip install --upgrade pip wheel
+
+# Setup pip mirror
+RUN mkdir -p /etc && \
+    printf "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple\ntimeout = 120\ntrusted-host = pypi.tuna.tsinghua.edu.cn\n" > /etc/pip.conf
+
+# Set up the application directory and copy source code into a subdirectory
+# DataFlow Commit b27d6bc24cf86835fda7bc6fe1a289cb9eb63bd2
+WORKDIR /app
+COPY . ./DataFlow/
+
+# Set the working directory to the project source
+WORKDIR /app/DataFlow
+
+# Install the project in editable mode with its dependencies
+RUN pip install -e ".[vllm]"
+
+# Set the container's default command to an interactive shell
+CMD ["/bin/bash"]

--- a/README-zh.md
+++ b/README-zh.md
@@ -120,6 +120,49 @@ open-dataflow codebase version: 1.0.0
 You are using the latest version: 1.0.0.
 ```
 
+#### 🐳 5.1.1 Docker安装（可选方式）
+
+我们还提供了 **Dockerfile** 以便于部署，同时也提供了**预构建的 Docker 镜像**供您直接使用。
+
+##### 方式一：使用预构建的 Docker 镜像
+
+您可以直接拉取并使用我们预构建的 Docker 镜像：
+
+```shell
+# 拉取预构建镜像
+docker pull molyheci/dataflow:cu124
+
+# 使用 GPU 支持运行容器
+docker run --gpus all -it molyheci/dataflow:cu124
+
+# 在容器内验证安装
+dataflow -v
+```
+
+##### 方式二：从 Dockerfile 构建
+
+或者，您也可以从项目提供的 Dockerfile 构建镜像：
+
+```shell
+# 克隆代码仓库（HTTPS 方式）
+git clone https://github.com/OpenDCAI/DataFlow.git
+# 或使用 SSH 方式
+# git clone git@github.com:OpenDCAI/DataFlow.git
+
+cd DataFlow
+
+# 构建 Docker 镜像
+docker build -t dataflow:custom .
+
+# 运行容器
+docker run --gpus all -it dataflow:custom
+
+# 在容器内验证安装
+dataflow -v
+```
+
+> **注意**：Docker 镜像包含 CUDA 12.4.1 支持，并预装了 vLLM 用于 GPU 加速。请确保您已安装 [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) 以使用 GPU 功能。
+
 ### 🚀 5.2 使用Gradio Web界面
 
 DataFlow提供了两个交互式Web界面，帮助你使用算子、流水线和智能体：

--- a/README.md
+++ b/README.md
@@ -129,6 +129,51 @@ open-dataflow codebase version: 1.0.0
 You are using the latest version: 1.0.0.
 ```
 
+#### 🐳 5.1.1 Docker Installation (Alternative)
+
+We also provide a **Dockerfile** for easy deployment and a **pre-built Docker image** for immediate use.
+
+##### Option 1: Use Pre-built Docker Image
+
+You can directly pull and use our pre-built Docker image:
+
+```shell
+# Pull the pre-built image
+docker pull molyheci/dataflow:cu124
+
+# Run the container with GPU support
+docker run --gpus all -it molyheci/dataflow:cu124
+
+# Inside the container, verify installation
+dataflow -v
+```
+
+##### Option 2: Build from Dockerfile
+
+Alternatively, you can build the Docker image from the provided Dockerfile:
+
+```shell
+# Clone the repository (HTTPS)
+git clone https://github.com/OpenDCAI/DataFlow.git
+# Or use SSH
+# git clone git@github.com:OpenDCAI/DataFlow.git
+
+cd DataFlow
+
+# Build the Docker image
+docker build -t dataflow:custom .
+
+# Run the container
+docker run --gpus all -it dataflow:custom
+
+# Inside the container, verify installation
+dataflow -v
+```
+
+> **Note**: The Docker image includes CUDA 12.4.1 support and comes with vLLM pre-installed for GPU acceleration. Make sure you have [NVIDIA Container Toolkit](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html) installed to use GPU features.
+
+
+
 ### 🚀 5.2 Using the Gradio Web Interface
 
 DataFlow provides two interactive web interfaces to help you use operators, pipelines, and agents:


### PR DESCRIPTION
Added Docker support with pre-built image and installation instructions to both English and Chinese README files. Users can now quickly get started using the pre-built image or build from the provided Dockerfile.
Docker Hub: [https://hub.docker.com/r/molyheci/dataflow](https://hub.docker.com/r/molyheci/dataflow)
The image comes with CUDA 12.4.1 and vLLM pre-installed for GPU acceleration.