### PR TITLE
Fix format problem of Reasoning Question Generator

### DIFF
--- a/dataflow/operators/reasoning/generate/reasoning_question_generator.py
+++ b/dataflow/operators/reasoning/generate/reasoning_question_generator.py
@@ -120,6 +120,15 @@ class ReasoningQuestionGenerator(OperatorABC):
 
         return formatted_prompts
 
+    def _parse_response(self, response: str):
+        # useful for reasoning llms. If response is in format of Deepseek thinking: <think>...</think><answer>...</answer>, keep only the answer part.
+        pattern = r"<think>(.*?)</think><answer>(.*?)</answer>"
+        matches = re.findall(pattern, response)
+        if matches:
+            return matches[0][1]
+        else:
+            return response
+    
     def run(
             self, 
             storage: DataFlowStorage, 
@@ -134,6 +143,7 @@ class ReasoningQuestionGenerator(OperatorABC):
         self._validate_dataframe(dataframe)
         formatted_prompts = self._reformat_prompt(dataframe)
         responses = self.llm_serving.generate_from_input(formatted_prompts)
+        responses = [self._parse_response(response) for response in responses]
 
         new_rows = pd.DataFrame({
             input_key: responses,


### PR DESCRIPTION
Our server will keep Deepseek thinking style like <think></think><answer></answer>. That's not good for question generation. So remove the think part and keep the final questions only.