### PR TITLE
fix: invocation of GetFilterFinalScorerPrompt

### DIFF
--- a/dataflow/statics/playground/simple_text_pipelines/core_filter.py
+++ b/dataflow/statics/playground/simple_text_pipelines/core_filter.py
@@ -169,7 +169,7 @@ class CoreFilterPipeline:
         )
         self.final_scorer = PromptedGenerator(
             llm_serving=llm_serving,
-            system_prompt=GetFilterFinalScorerPrompt
+            system_prompt=GetFilterFinalScorerPrompt()
         )
         self.final_filter = GeneralFilter([lambda df: df['final_score'] >= 4])
     


### PR DESCRIPTION
开发者你们好，我在使用 [core_filter.py](https://github.com/OpenDCAI/DataFlow/blob/main/dataflow/statics/playground/simple_text_pipelines/core_filter.py) 时注意到 GetFilterFinalScorerPrompt 的函数调用缺少括号。检查 PromptedGenerator 发现 system_prompt 应当接受字符串作为参数，因此我认为不应该直接传入函数对象。如有误会还请指正，谢谢。