### PR TITLE
[Batched Storage] Reset index after slicing dataframe in storage.py

### DIFF
--- a/dataflow/utils/storage.py
+++ b/dataflow/utils/storage.py
@@ -1018,7 +1018,7 @@ class BatchedFileStorage(FileStorage):
         if self.batch_size:
             dataframe = dataframe.iloc[
                 self.batch_step * self.batch_size : (self.batch_step + 1) * self.batch_size
-            ].reset_index(drop=True)
+            ].reset_index(drop=True) # reset_index, make the new index of every batch start from 0. Instead of its original index.
         return self._convert_output(dataframe, output_type)
     
     def write(self, data: Any) -> Any:


### PR DESCRIPTION
Fix indexing to reset index after slicing dataframe.