### PR TITLE
Change fasttext-wheel to fasttext in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -31,9 +31,11 @@ cookiecutter # auto template gen from CLI
 func_timeout
 sqlglot
 pymysql
+
 # general text
-fasttext; python_version >= "3.13"
-fasttext-wheel; python_version < "3.13"
+fasttext; python_version >= "3.13" # https://github.com/OpenDCAI/DataFlow/pull/470
+fasttext-wheel; python_version < "3.13" # https://github.com/OpenDCAI/DataFlow/pull/470
+
 langkit
 openai
 sentencepiece


### PR DESCRIPTION
The fastText project has been archived, and it looks like the latest version is now only in the `fasttext` package in PyPI, not `fasttext-wheel`. This change switches to using `fasttext` (0.9.3).

The reason for this is because the wheel published as `fasttext-wheel==0.9.2` doesn't build properly for me under Python 3.13, but the version hosted as `fasttext==0.9.3` does.