### PR TITLE
[deps] Raise transformers lower bound to >=4.51.0 (CVE-2025-3263)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,7 @@ pdf2model-dataflex =[
     "gradio>=4.38.0,<=5.13.0",
     "llamafactory[torch,metrics]>=0.9.4",
     "vllm>=0.8.0,<0.9.0",         
-    "transformers>=4.48.1,<=4.52.0", 
+    "transformers>=4.51.0,<=4.52.0", 
     "tokenizers>=0.19.0,<=0.21.1",
     "datasets>=2.16.0,<=3.2.0",      
     "fsspec<=2024.9.0",              


### PR DESCRIPTION
The transformers range >=4.48.1,<=4.52.0 permitted 4.48.x, which is affected by CVE-2025-3263 (ReDoS, fixed in 4.51.0). Raising the lower bound to >=4.51.0 prevents an accidental downgrade into the affected range while staying within the existing <=4.52.0 cap.

Closes #506