### PR TITLE
docs: quote pip extras install examples

### DIFF
--- a/README-zh.md
+++ b/README-zh.md
@@ -246,7 +246,7 @@ uv pip install open-dataflow
 
 ```shell
 pip install uv
-uv pip install 'open-dataflow[vllm]'
+uv pip install "open-dataflow[vllm]"
 
 ```
 

--- a/README-zh.md
+++ b/README-zh.md
@@ -246,7 +246,7 @@ uv pip install open-dataflow
 
 ```shell
 pip install uv
-uv pip install open-dataflow[vllm]
+uv pip install 'open-dataflow[vllm]'
 
 ```
 

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ If you want to use your own GPU for local inference, please use:
 
 ```shell
 pip install uv
-uv pip install 'open-dataflow[vllm]'
+uv pip install "open-dataflow[vllm]"
 ```
 
 After installation, you can use the following command to check if dataflow has been installed correctly:

--- a/README.md
+++ b/README.md
@@ -264,7 +264,7 @@ If you want to use your own GPU for local inference, please use:
 
 ```shell
 pip install uv
-uv pip install open-dataflow[vllm]
+uv pip install 'open-dataflow[vllm]'
 ```
 
 After installation, you can use the following command to check if dataflow has been installed correctly:


### PR DESCRIPTION
## Summary
- Quote `pip install` examples that include extras.

## Why
- Shells such as zsh can expand unquoted bracket expressions before `pip` receives them.

## Scope
- Files changed:
- `README-zh.md`
- `README.md`
- This does not change dependencies or runtime behavior.

## Testing
- `git diff --check`

## Maintainer Fit
- Small install-command correctness fix.
- Duplicate PR search terms checked: `quote pip extras`, `quote optional dependency`, `zsh pip install extras`, `pip extras install examples`