### PR TITLE
fix(reasoning): prevent branch root filter from overwriting step output

### DIFF
--- a/dataflow/operators/reasoning/filter/reasoning_answer_pipeline_root_filter.py
+++ b/dataflow/operators/reasoning/filter/reasoning_answer_pipeline_root_filter.py
@@ -16,80 +16,100 @@ class ReasoningAnswerPipelineRootFilter(OperatorABC):
     def get_desc(lang: str = "zh"):
         if lang == "zh":
             return (
-                "答案处理流程根节点，负责将输入数据根据有无真实标签GT分发到不同处理分支。\n\n"
-                "输入参数：\n"
-                "- input_file：输入文件路径\n"
-                "- output_dir：输出目录路径\n"
-                "- branch_config：分支配置参数\n"
-                "- parallel_workers：并行工作线程数\n\n"
-                "输出参数：\n"
-                "- 多个输出文件路径（根据分支配置生成）"
+                "根据样本是否具有 Ground Truth 对答案数据进行路由标记。"
+                "算子会尝试从答案字段补充缺失的 Ground Truth，并在输出字段中写入 "
+                "'with_gt' 或 'without_gt'。所有记录通过一次写入传递给下一步骤。"
             )
-        elif lang == "en":
+        if lang == "en":
             return (
-                "Root node of answer processing pipeline, distributes input data to different processing branches.\n\n"
-                "Input Parameters:\n"
-                "- input_file: Input file path\n"
-                "- output_dir: Output directory path\n"
-                "- branch_config: Branch configuration parameters\n"
-                "- parallel_workers: Number of parallel workers\n\n"
-                "Output Parameters:\n"
-                "- Multiple output file paths (generated based on branch config)"
+                "Annotate answer rows according to whether Ground Truth exists. "
+                "Missing Ground Truth may be extracted from the answer column. "
+                "The output branch column contains 'with_gt' or 'without_gt', "
+                "and all rows are persisted with a single storage write."
             )
-        else:
-            return "AnswerPipelineRoot routes data to different processing branches."
+        return "Annotate answer rows with Ground Truth routing information."
 
-    def run(self, storage: DataFlowStorage, input_answer_key: str = "output", input_gt_key: str = "golden_answer"):
-        self.input_answer_key = input_answer_key
-        self.input_gt_key = input_gt_key
-        
-        df = storage.read("dataframe")
+    def run(
+        self,
+        storage: DataFlowStorage,
+        input_answer_key: str = "output",
+        input_gt_key: str = "golden_answer",
+        output_branch_key: str = "answer_branch",
+    ) -> list[str]:
+        """Annotate rows according to whether a ground-truth answer exists.
 
-        if not self.input_gt_key or self.input_gt_key not in df.columns:
-            self.logger.warning("No valid gt key in input file, copy input file to output file without gt")
-            return
-            
-        # 初始化答案提取器
-        if self.input_answer_key in df.columns:
+        The current DataFlow storage contract is linear: one operator step writes
+        one downstream dataset. Therefore this operator records the routing result
+        in ``output_branch_key`` and performs exactly one storage write.
+        """
+        dataframe = storage.read("dataframe").copy()
+
+        if not input_gt_key:
+            self.logger.warning(
+                "No valid gt key provided; falling back to 'golden_answer'."
+            )
+            input_gt_key = "golden_answer"
+
+        if input_gt_key not in dataframe.columns:
+            self.logger.warning(
+                "Ground-truth column '%s' is missing; creating an empty column.",
+                input_gt_key,
+            )
+            dataframe[input_gt_key] = None
+
+        if input_answer_key in dataframe.columns:
             unit_text_manager = UnitTextManager()
             string_cleaner = StringCleaner(unit_text_manager)
             answer_extractor = AnswerExtractor(string_cleaner)
-        
-            def extract_gt(answer, gt):
-                try:
-                    if gt != "" and not pd.isna(gt):
-                        return gt
-                    else:
-                        if pd.isna(answer) or answer == "":
-                            return None
-                        else:
-                            return answer_extractor.extract_answer(answer,None,True)
-                except Exception as e:
-                    self.logger.error(f"Error in extract_gt: {e}", exc_info=True)
+
+            def resolve_ground_truth(row):
+                ground_truth = row[input_gt_key]
+                if pd.notna(ground_truth) and ground_truth != "":
+                    return ground_truth
+
+                answer = row[input_answer_key]
+                if pd.isna(answer) or answer == "":
                     return None
-            
-            # 使用 apply 遍历 DataFrame, 避免显式循环索引问题
-            df[self.input_gt_key] = df.apply(lambda row: extract_gt(row[self.input_answer_key],
-                                                                    row[self.input_gt_key]),
-                                            axis=1)
-        
-        # 拆分有gt和无gt的 DataFrame
-        df_with_gt = df[(df[self.input_gt_key].notna()) & (df[self.input_gt_key] != "")]
-        df_without_gt = df[(df[self.input_gt_key].isna()) | (df[self.input_gt_key] == "")].copy()
-        df_without_gt[self.input_gt_key] = None
 
-        # 输出结果
-        if len(df_with_gt) > 0:
-            output_file_gt = storage.write(df_with_gt)
-            self.logger.info(f"output {df_with_gt.shape[0]} rows with gt to {output_file_gt}")
+                try:
+                    return answer_extractor.extract_answer(answer, None, True)
+                except Exception as exc:
+                    self.logger.warning(
+                        "Failed to extract ground truth from '%s': %s",
+                        input_answer_key,
+                        exc,
+                    )
+                    return None
 
-        if len(df_without_gt) > 0:
-            output_file_without_gt = storage.write(df_without_gt)
-            self.logger.info(f"output {df_without_gt.shape[0]} rows without gt to {output_file_without_gt}")
-                    
-            
+            dataframe[input_gt_key] = dataframe.apply(
+                resolve_ground_truth,
+                axis=1,
+            )
+        else:
+            self.logger.warning(
+                "Answer column '%s' is missing; existing ground-truth values "
+                "will be used without answer extraction.",
+                input_answer_key,
+            )
 
+        has_ground_truth = (
+            dataframe[input_gt_key].notna()
+            & dataframe[input_gt_key].ne("")
+        )
 
+        dataframe[output_branch_key] = "without_gt"
+        dataframe.loc[has_ground_truth, output_branch_key] = "with_gt"
 
-        
-        
+        output_file = storage.write(dataframe)
+
+        with_gt_count = int(has_ground_truth.sum())
+        without_gt_count = len(dataframe) - with_gt_count
+        self.logger.info(
+            "Saved %d rows to %s: with_gt=%d, without_gt=%d",
+            len(dataframe),
+            output_file,
+            with_gt_count,
+            without_gt_count,
+        )
+
+        return [input_gt_key, output_branch_key]

--- a/dataflow/operators/reasoning/filter/reasoning_answer_pipeline_root_filter.py
+++ b/dataflow/operators/reasoning/filter/reasoning_answer_pipeline_root_filter.py
@@ -16,18 +16,33 @@ class ReasoningAnswerPipelineRootFilter(OperatorABC):
     def get_desc(lang: str = "zh"):
         if lang == "zh":
             return (
-                "根据样本是否具有 Ground Truth 对答案数据进行路由标记。"
-                "算子会尝试从答案字段补充缺失的 Ground Truth，并在输出字段中写入 "
-                "'with_gt' 或 'without_gt'。所有记录通过一次写入传递给下一步骤。"
+                "该算子根据样本是否具有 Ground Truth 添加答案分支标记，"
+                "并尝试从答案字段中提取缺失的 Ground Truth。\n\n"
+                "输入参数：\n"
+                "- input_answer_key：答案字段名，默认为'output'\n"
+                "- input_gt_key：Ground Truth 字段名，默认为'golden_answer'\n"
+                "- output_branch_key：分支标记字段名，默认为'answer_branch'\n\n"
+                "输出行为：\n"
+                "- Ground Truth 存在时标记为'with_gt'\n"
+                "- Ground Truth 缺失时标记为'without_gt'\n"
+                "- 保留全部样本，并通过一次写入传递给下一步骤"
             )
-        if lang == "en":
+        elif lang == "en":
             return (
-                "Annotate answer rows according to whether Ground Truth exists. "
-                "Missing Ground Truth may be extracted from the answer column. "
-                "The output branch column contains 'with_gt' or 'without_gt', "
-                "and all rows are persisted with a single storage write."
+                "This operator labels answer rows according to whether Ground Truth "
+                "is available and attempts to extract missing Ground Truth from the "
+                "answer field.\n\n"
+                "Input Parameters:\n"
+                "- input_answer_key: Answer column, default is 'output'\n"
+                "- input_gt_key: Ground Truth column, default is 'golden_answer'\n"
+                "- output_branch_key: Branch marker column, default is 'answer_branch'\n\n"
+                "Output Behavior:\n"
+                "- Mark rows with Ground Truth as 'with_gt'\n"
+                "- Mark rows without Ground Truth as 'without_gt'\n"
+                "- Preserve all rows and pass them to the next step with a single write"
             )
-        return "Annotate answer rows with Ground Truth routing information."
+        else:
+            return "Annotate answer rows with Ground Truth availability."
 
     def run(
         self,

--- a/test/cpu_only/test_reasoning_answer_pipeline_root_filter.py
+++ b/test/cpu_only/test_reasoning_answer_pipeline_root_filter.py
@@ -1,0 +1,139 @@
+import importlib
+import pandas as pd
+import pytest
+
+from dataflow.operators.reasoning import ReasoningAnswerPipelineRootFilter
+from dataflow.utils.storage import DataFlowStorage
+
+
+class SpyStorage(DataFlowStorage):
+    def __init__(self, dataframe: pd.DataFrame):
+        self.dataframe = dataframe.copy()
+        self.result = None
+        self.write_count = 0
+
+    def get_keys_from_dataframe(self) -> list[str]:
+        return self.dataframe.columns.tolist()
+
+    def read(self, output_type="dataframe"):
+        if output_type == "dataframe":
+            return self.dataframe.copy()
+        if output_type == "dict":
+            return self.dataframe.to_dict("records")
+        raise ValueError(f"Unsupported output type: {output_type}")
+
+    def write(self, data):
+        self.write_count += 1
+        self.result = data.copy()
+        return "memory://reasoning-root-filter"
+
+
+@pytest.mark.cpu
+def test_root_filter_writes_once_and_preserves_both_groups():
+    storage = SpyStorage(
+        pd.DataFrame(
+            [
+                {"instruction": "q1", "golden_answer": "1"},
+                {"instruction": "q2", "golden_answer": None},
+            ]
+        )
+    )
+
+    operator = ReasoningAnswerPipelineRootFilter()
+    result_keys = operator.run(
+        storage=storage,
+        input_answer_key="missing_answer",
+        input_gt_key="golden_answer",
+        output_branch_key="answer_branch",
+    )
+
+    assert storage.write_count == 1
+    assert len(storage.result) == 2
+    assert storage.result["answer_branch"].tolist() == [
+        "with_gt",
+        "without_gt",
+    ]
+    assert result_keys == ["golden_answer", "answer_branch"]
+
+
+@pytest.mark.cpu
+def test_root_filter_creates_missing_gt_column_and_still_writes():
+    storage = SpyStorage(
+        pd.DataFrame(
+            [
+                {"instruction": "q1"},
+                {"instruction": "q2"},
+            ]
+        )
+    )
+
+    operator = ReasoningAnswerPipelineRootFilter()
+    operator.run(
+        storage=storage,
+        input_answer_key="missing_answer",
+        input_gt_key="golden_answer",
+        output_branch_key="answer_branch",
+    )
+
+    assert storage.write_count == 1
+    assert "golden_answer" in storage.result.columns
+    assert storage.result["golden_answer"].isna().all()
+    assert (storage.result["answer_branch"] == "without_gt").all()
+
+
+@pytest.mark.cpu
+def test_root_filter_marks_all_existing_gt_rows():
+    storage = SpyStorage(
+        pd.DataFrame(
+            [
+                {"golden_answer": "1"},
+                {"golden_answer": "2"},
+            ]
+        )
+    )
+
+    operator = ReasoningAnswerPipelineRootFilter()
+    operator.run(
+        storage=storage,
+        input_answer_key="missing_answer",
+        input_gt_key="golden_answer",
+        output_branch_key="answer_branch",
+    )
+
+    assert storage.write_count == 1
+    assert len(storage.result) == 2
+    assert (storage.result["answer_branch"] == "with_gt").all()
+
+
+@pytest.mark.cpu
+def test_root_filter_extracts_missing_gt_from_answer(monkeypatch):
+    def fake_extract_answer(self, answer, *_args, **_kwargs):
+        return "42" if answer else None
+
+    root_filter_module = importlib.import_module(
+        "dataflow.operators.reasoning.filter.reasoning_answer_pipeline_root_filter"
+    )
+    def fake_extract_answer(self, answer, *_args, **_kwargs):
+        return "42" if answer else None
+
+    monkeypatch.setattr(
+        root_filter_module.AnswerExtractor, "extract_answer", fake_extract_answer,
+    )
+
+    storage = SpyStorage(
+        pd.DataFrame(
+            [
+                {
+                    "output": "The final answer is 42.",
+                    "golden_answer": None,
+                }
+            ]
+        )
+    )
+
+    operator = ReasoningAnswerPipelineRootFilter()
+    operator.run(storage=storage)
+
+    assert storage.write_count == 1
+    assert storage.result.loc[0, "golden_answer"] == "42"
+    assert storage.result.loc[0, "answer_branch"] == "with_gt"


### PR DESCRIPTION
Fixes #520

## Problem

`ReasoningAnswerPipelineRootFilter` may call `storage.write()` twice during a single pipeline step. Both writes target the same step file, so the second write overwrites the first. When the GT column is missing, the operator returns without writing and breaks the next pipeline step.

## Solution

- Write exactly once per operator execution.
- Preserve all input rows.
- Create a missing GT column instead of returning early.
- Add an answer branch marker with `with_gt` and `without_gt` values.
- Add CPU-only regression tests.

## Scope

This PR does not introduce true DAG branching. It makes the existing operator safe under DataFlow's current linear storage model.

## Tests

4 new CPU-only regression tests in `test/cpu_only/test_reasoning_answer_pipeline_root_filter.py`, all passing locally.