### PR TITLE
Fixes #407: Support cross-file (cross-jsonl) MinHash deduplication

### DIFF
--- a/dataflow/operators/general_text/filter/minhash_deduplicate_filter.py
+++ b/dataflow/operators/general_text/filter/minhash_deduplicate_filter.py
@@ -1,3 +1,6 @@
+import pickle
+import uuid
+import os
 from tqdm import tqdm
 from datasketch import MinHash, MinHashLSH  # use datasketch-1.6.5
 from dataflow import get_logger
@@ -7,13 +10,14 @@ from dataflow.utils.registry import OPERATOR_REGISTRY
 
 @OPERATOR_REGISTRY.register()
 class MinHashDeduplicateFilter(OperatorABC):
-    def __init__(self, num_perm=128, threshold=0.9, use_n_gram=True, ngram=5):
+    def __init__(self, num_perm=128, threshold=0.9, use_n_gram=True, ngram=5, index_path=None):
         self.logger = get_logger()
         self.num_perm = num_perm
         self.threshold = threshold
         self.use_n_gram = use_n_gram
         self.n_gram = ngram
-        self.logger.info(f"Initializing {self.__class__.__name__} with num_perm = {self.num_perm}, threshold = {self.threshold}, use_n_gram = {self.use_n_gram}, ngram = {self.n_gram}...")
+        self.index_path = index_path
+        self.logger.info(f"Initializing {self.__class__.__name__} with num_perm = {self.num_perm}, threshold = {self.threshold}, use_n_gram = {self.use_n_gram}, ngram = {self.n_gram}, index_path = {self.index_path}...")
 
     @staticmethod
     def get_desc(lang: str = "zh"):
@@ -25,6 +29,7 @@ class MinHashDeduplicateFilter(OperatorABC):
                 "- threshold：相似度阈值，超过此阈值判定为相似文本\n"
                 "- use_n_gram：是否使用n-gram分词\n"
                 "- ngram：n-gram的n值\n"
+                "- index_path：LSH索引持久化路径（可选）。设置后启用跨文件去重模式：每次run()会加载已有索引、去重、保存索引。\n"
                 "输出参数：\n"
                 "- 去重后的DataFrame，仅保留唯一文本\n"
                 "- 返回包含去重标签字段名的列表"
@@ -36,7 +41,8 @@ class MinHashDeduplicateFilter(OperatorABC):
                 "- num_perm: Number of permutations for generating MinHash signatures\n"
                 "- threshold: Similarity threshold above which texts are considered duplicates\n"
                 "- use_n_gram: Whether to use n-gram tokenization\n"
-                "- ngram: n value for n-gram\n\n"
+                "- ngram: n value for n-gram\n"
+                "- index_path: Optional path for persisting the LSH index to disk. When set, enables cross-file deduplication: each run() loads the existing index, deduplicates against it, and saves the updated index for the next file.\n"
                 "Output Parameters:\n"
                 "- Deduplicated DataFrame containing only unique texts\n"
                 "- List containing deduplication label field name"
@@ -63,13 +69,51 @@ class MinHashDeduplicateFilter(OperatorABC):
             self.logger.info(f"Running {self.__class__.__name__} with input_keys = {input_keys} and output_key = {output_key}")
         else:
             self.logger.info(f"Running {self.__class__.__name__} with input_key = {input_key} and output_key = {output_key}")
-        lsh = MinHashLSH(threshold=self.threshold, num_perm=self.num_perm)
+
+        # --- Cross-file persistence logic ---
+        # When index_path is set, load/save LSH index via pickle across run() calls.
+        # Each run() uses a unique file identifier (UUID4) to prefix LSH keys, ensuring
+        # no key collisions between files when deduplicating across multiple jsonl files.
+        if self.index_path is not None:
+            try:
+                if os.path.exists(self.index_path):
+                    with open(self.index_path, 'rb') as f:
+                        lsh = pickle.load(f)
+                    self.logger.info(f"Loaded LSH index from {self.index_path} ({lsh.get_counts()} buckets)")
+                else:
+                    lsh = MinHashLSH(threshold=self.threshold, num_perm=self.num_perm)
+                    self.logger.info(f"No existing index at {self.index_path}, created new LSH index")
+            except Exception as e:
+                self.logger.warning(f"Failed to load LSH index from {self.index_path}: {e}. Creating fresh index.")
+                lsh = MinHashLSH(threshold=self.threshold, num_perm=self.num_perm)
+            # Generate a unique prefix for keys in this run to avoid cross-file collisions
+            file_id = uuid.uuid4().hex[:8]
+        else:
+            lsh = MinHashLSH(threshold=self.threshold, num_perm=self.num_perm)
+            file_id = None
+
         self.input_key = input_key
         self.input_keys = input_keys
         self.output_key = output_key
         dataframe = storage.read("dataframe")
+
+        # Handle empty DataFrame edge case
+        if len(dataframe) == 0:
+            self.logger.warning("Empty DataFrame received, nothing to deduplicate.")
+            if self.index_path is not None:
+                try:
+                    with open(self.index_path, 'wb') as f:
+                        pickle.dump(lsh, f)
+                    self.logger.info(f"Saved LSH index to {self.index_path}")
+                except Exception as e:
+                    self.logger.warning(f"Failed to save LSH index to {self.index_path}: {e}")
+            dataframe[self.output_key] = []
+            filtered_dataframe = dataframe
+            output_file = storage.write(filtered_dataframe)
+            return [self.output_key,]
+
         labels = [0] * len(dataframe)
-        with lsh.insertion_session() as session:  
+        with lsh.insertion_session() as session:
             for idx, sample in tqdm(enumerate(dataframe.to_dict(orient='records')), desc=f"Implementing {self.__class__.__name__}", total=len(dataframe)):
                 if input_keys is not None and len(input_keys) > 1:
                     text = '\n'.join([f"{k}:\n{sample[k]}" for k in input_keys])
@@ -77,11 +121,23 @@ class MinHashDeduplicateFilter(OperatorABC):
                     text = sample[self.input_key]
                 minhash = self.create_minhash(text)
                 result = lsh.query(minhash)
-                
+
                 if len(result) == 0:
                     labels[idx] = 1
-                    session.insert(idx, minhash)
-                    self.logger.debug(f"Inserted item {idx} into LSH with minhash.")
+                    # Use globally unique key: file_id prefix ensures cross-file uniqueness
+                    lsh_key = f"{file_id}_{idx}" if file_id is not None else idx
+                    session.insert(lsh_key, minhash)
+                    self.logger.debug(f"Inserted item {lsh_key} into LSH with minhash.")
+
+        # Persist index to disk for cross-file deduplication
+        if self.index_path is not None:
+            try:
+                with open(self.index_path, 'wb') as f:
+                    pickle.dump(lsh, f)
+                self.logger.info(f"Saved LSH index to {self.index_path}")
+            except Exception as e:
+                self.logger.warning(f"Failed to save LSH index to {self.index_path}: {e}")
+
         dataframe[self.output_key] = labels
         filtered_dataframe = dataframe[(dataframe[self.output_key] > 0)]
         output_file = storage.write(filtered_dataframe)


### PR DESCRIPTION
## Summary
Fixes #407. Extends \`MinHashDeduplicateFilter\` to support near-duplicate detection **across multiple jsonl files** (cross-file), not just within a single file.

## Changes
- Added optional \`index_path\` constructor parameter (default \`None\`).
  - \`None\` → unchanged behavior (fresh in-memory LSH per \`run()\`).
  - set → loads an existing LSH index from disk at the start of \`run()\`, deduplicates incoming records against the shared index, and saves the updated index back, so the next file reuses it.
- LSH keys are prefixed with a per-run \`uuid4\` (\`file_id\`) to guarantee uniqueness across files.
- Handles empty DataFrame edge case.
- Documents the new parameter in both zh/en \`get_desc\`.

## Usage
\`\`\`python
op = MinHashDeduplicateFilter(index_path="/tmp/lsh_index.pkl")
op.run(storage1, input_key="text")  # file 1, builds index
op.run(storage2, input_key="text")  # file 2, deduped against file 1
op.run(storage3, input_key="text")  # shares the same index
\`\`\`

## Limitations
- Reusing the same \`index_path\` with different \`threshold\`/\`num_perm\` between runs is unsupported (loaded index may have incompatible parameters).
- Index size grows with the number of unique items across all processed files.

## Test plan
- [ ] Single-file behavior unchanged when \`index_path=None\` (backward compatible).
- [ ] Cross-file duplicates are detected when reusing \`index_path\`.